### PR TITLE
Version bump

### DIFF
--- a/.version-bump.lock
+++ b/.version-bump.lock
@@ -1,4 +1,7 @@
 {"name":"gha-uses-commit","key":"https://github.com/actions/checkout.git:v6.0.2","version":"de0fac2e4500dabe0009e67214ff5f5447ce83dd"}
 {"name":"gha-uses-semver","key":"https://github.com/actions/checkout.git","version":"v6.0.2"}
-{"name":"netlify-hugo","key":"https://github.com/gohugoio/hugo.git","version":"0.162.0"}
+{"name":"makefile-geekdoc-theme","key":"https://github.com/thegeeklab/hugo-geekdoc.git","version":"v4.1.1"}
+{"name":"makefile-hugo","key":"https://github.com/gohugoio/hugo.git","version":"v0.162.1"}
+{"name":"makefile-markdown-lint","key":"docker.io/davidanson/markdownlint-cli2","version":"v0.22.1"}
+{"name":"netlify-hugo","key":"https://github.com/gohugoio/hugo.git","version":"0.162.1"}
 {"name":"netlify-node","key":"https://github.com/nodejs/node.git","version":"26"}

--- a/.version-bump.yml
+++ b/.version-bump.yml
@@ -68,19 +68,19 @@ processors:
   makefile-geekdoc-theme:
     <<: *git-tag-semver
     scanArgs:
-      regexp: '^THEME_VERSION\s*=\s*(?P<Version>v?[0-9\.]+)\s*$'
+      regexp: '^THEME_VERSION\s*\??=\s*(?P<Version>v?[0-9\.]+)\s*$'
     sourceArgs:
       url: "https://github.com/thegeeklab/hugo-geekdoc.git"
   makefile-hugo:
     <<: *git-tag-semver
     scanArgs:
-      regexp: '^HUGO_VERSION\s*=\s*(?P<Version>v?[0-9\.]+)\s*$'
+      regexp: '^HUGO_VERSION\s*\??=\s*(?P<Version>v?[0-9\.]+)\s*$'
     sourceArgs:
       url: "https://github.com/gohugoio/hugo.git"
   makefile-markdown-lint:
     <<: *registry-tag-semver
     scanArgs:
-      regexp: '^MARKDOWN_LINT_VER\s*=\s*(?P<Version>v?[0-9\.]+)\s*$'
+      regexp: '^MARKDOWN_LINT_VER\s*\??=\s*(?P<Version>v?[0-9\.]+)\s*$'
     sourceArgs:
       repo: "docker.io/davidanson/markdownlint-cli2"
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 DOCKER?=$(shell command -v docker 2>/dev/null)
 HUGO?=$(shell command -v hugo 2>/dev/null)
 HUGO_CMD_VER:=$(shell [ -x "$(HUGO)" ] && echo "$$($(HUGO) version | awk '{print $$2}')" || echo "0")
-HUGO_VERSION?=v0.141.0
+HUGO_VERSION?=v0.162.1
 HUGO_CONTAINER?=ghcr.io/gohugoio/hugo:$(HUGO_VERSION)
 ifneq "$(HUGO_CMD_VER)" "$(HUGO_VERSION)"
 	ifneq "$(strip $(DOCKER))" ""
@@ -11,10 +11,10 @@ ifneq "$(HUGO_CMD_VER)" "$(HUGO_VERSION)"
 			$(HUGO_CONTAINER)
 	endif
 endif
-THEME_VERSION?=v1.3.0
+THEME_VERSION?=v4.1.1
 THEME?=hugo-geekdoc
 CLI_CMDS?=olareg
-MARKDOWN_LINT_VER?=v0.17.2
+MARKDOWN_LINT_VER?=v0.22.1
 VER_BUMP?=$(shell command -v version-bump 2>/dev/null)
 VER_BUMP_CONTAINER?=sudobmitch/version-bump:edge
 ifeq "$(strip $(VER_BUMP))" ''

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build.environment]
-HUGO_VERSION = "0.162.0"
+HUGO_VERSION = "0.162.1"
 NODE_VERSION = "26"
 TZ = "America/Los_Angeles"
 


### PR DESCRIPTION
- Fix version bump for makefile entries
- thegeeklab/hugo-geekdoc to v4.1.1
- gohugoio/hugo to v0.162.1
- davidanson/markdownlint-cli2 to v0.22.1